### PR TITLE
games 라우터 오류 수정

### DIFF
--- a/src/lib/errors/classes/team-not-ready.error.js
+++ b/src/lib/errors/classes/team-not-ready.error.js
@@ -1,6 +1,7 @@
 class TeamNotReadyError extends Error {
   constructor(msg) {
-    super.message = msg || "팀 구성이 올바르지 않습니다.";
+    super(msg);
+    this.message = msg || "팀 구성이 올바르지 않습니다.";
     this.name = "TeamNotReadyError";
     this.code = 409;
   }

--- a/src/lib/errors/error-checker.js
+++ b/src/lib/errors/error-checker.js
@@ -81,10 +81,13 @@ const errorChecker = {
 
   teamChecker: async function (userId, select) {
     const query = queryBuilder({ UserId: userId }, select);
-    const team = await userPrisma.findMany(query);
+    query.include = {
+      Inventory: true,
+    };
+    const team = await userPrisma.team.findMany(query);
     if (team.length != 3) throw new TeamNotReadyError();
     return team;
   },
 };
 
-export default errorChecker
+export default errorChecker;

--- a/src/routes/games.route.js
+++ b/src/routes/games.route.js
@@ -17,13 +17,11 @@ const MODIFIERS = {
 
 const calcTeamPower = async (team) => {
   return team.reduce(async (acc, member) => {
-    const inventory = await userPrisma.inventory.findFirst({
-      where: { InventoryId: member.InventoryId },
-    });
-    const player = await ec.playerChecker(inventory.PlayerId);
+    const player = await ec.playerChecker(member.PlayerId);
     const tier = await playerPrisma.tier.findUnique({
-      where: { tierName: player.tierName },
+      where: { TierName: player.TierName },
     });
+    // member.level
 
     acc +=
       (player.speed + tier.bonus[`${inventory.level}`]) * MODIFIERS.speed +
@@ -80,8 +78,9 @@ router.post(
   uv.userIdParamsValidation,
   async (req, res, next) => {
     try {
-      const result = play(req.body.user.userId, req.params.userId);
-      if (result == 0)
+      const result = await play(req.body.user.userId, req.params.userId);
+
+      if (result === 0)
         return res.status(200).json({ message: "무승부입니다." });
       else if (result > 0)
         return res.status(200).json({ message: "승리했습니다!" });

--- a/src/routes/games.route.js
+++ b/src/routes/games.route.js
@@ -77,7 +77,7 @@ const matchMaking = () => {};
 router.post(
   "/games/versus/:userId",
   ua.authStrict,
-  uv.userIdValidation,
+  uv.userIdParamsValidation,
   async (req, res, next) => {
     try {
       const result = play(req.body.user.userId, req.params.userId);

--- a/src/routes/games.route.js
+++ b/src/routes/games.route.js
@@ -75,15 +75,17 @@ const play = async (a, b) => {
 const matchMaking = () => {};
 
 router.post(
-  "/games/play/:userId",
+  "/games/versus/:userId",
   ua.authStrict,
   uv.userIdValidation,
   async (req, res, next) => {
     try {
       const result = play(req.body.user.userId, req.params.userId);
-      if (result == 0) res.status(200).json({ message: "무승부입니다." });
-      else if (result > 0) res.status(200).json({ message: "승리했습니다!" });
-      else res.status(200).json({ message: "패배했습니다." });
+      if (result == 0)
+        return res.status(200).json({ message: "무승부입니다." });
+      else if (result > 0)
+        return res.status(200).json({ message: "승리했습니다!" });
+      else return res.status(200).json({ message: "패배했습니다." });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## 관련 Issue

<!--관련 issue 번호를 #4, close #5 같은 형식으로 추가-->
<!-- close #1, #2, close #3 -->

#8

---

## 작업 내용

src/routes/games.route.js
- await 키워드가 없어서 에러를 catch하지 못하던 문제 수정
- calcTeamPower에서 inventory query 제거
- calcTeamPower에서 tier query의 where 내 field 이름과 그 값의 key 이름을 schema에 맞게 수정

src/lib/errors/classes/team-not-ready.error.js
- constructor에서 super constructor를 호출하지 않던 문제 수정

src/lib/errors/error-checker.js
- teamChecker의 team query에서 inventory relation 정보를 포함 하도록 변경

---

## 비고

<!--특이사항 작성-->

-
