### PR TITLE
gachaerrorcheck

### DIFF
--- a/src/routes/stores.route.js
+++ b/src/routes/stores.route.js
@@ -6,15 +6,15 @@ import { playerPrisma, userPrisma } from "../lib/utils/prisma/index.js";
 
 const router = express.Router();
 const GACHA_STANDARD_PACK_PRICE = 1000;
-const GACHA_STANDARD_PACK_RATES = [0.05, 0.1, 0.2, 0.3, 0.35]; //
+const GACHA_STANDARD_PACK_RATES = [5, 10, 20, 30, 35]; //
 // const GACHA_MAX = 5; // 0~4, 5 is converted to 4
 
 const gacha = async () => {
   // implement gacha logic, returns player
-  const gachaTier = Math.random();
+  const gachaTier = Math.floor(Math.random() * 99 + 1);
   let acc = 0;
   for (let i = 0; i < GACHA_STANDARD_PACK_RATES.length; i++) {
-    if ((acc += GACHA_STANDARD_PACK_RATES[i]) <= gachaTier) {
+    if ((acc += GACHA_STANDARD_PACK_RATES[i]) >= gachaTier) {
       acc = i;
       break;
     }


### PR DESCRIPTION
뽑기를 할 때, 뽑기가 확률표로 안나오고 0티어만 뽑히는 현상 수정

## 관련 Issue

<!--관련 issue 번호를 #4, close #5 같은 형식으로 추가-->
<!-- close #1, #2, close #3 -->

없음

---

## 작업 내용

- 뽑기 시 확률표대로 뽑기가 진행되게 끔 수정
---

## 비고

<!--특이사항 작성-->

- 없음
