### PR TITLE
inventory 라우터 기능 수정

### DIFF
--- a/src/lib/utils/tier-utils.js
+++ b/src/lib/utils/tier-utils.js
@@ -1,29 +1,73 @@
-import { playerPrisma } from "./prisma/index.js";
+import { playerPrisma, userPrisma } from "./prisma/index.js";
 
 let tiers = null;
 
 const init = async () => {
   tiers = await playerPrisma.$queryRaw`
-    SELECT * FROM Tier
+    SELECT tier_name as tierName,
+      bonus,
+      success_rate as successRate
+    FROM Tier
+    ORDER BY 1
   `;
 };
 
 const tierUtils = {
   /**
    * Applies actual player stats to the inventory's player data based on its level.
-   * @param {Object} inventory from table Inventory in game_db
+   * @param {Object} inventory from Inventory table in game_db, w. player's stats included
    * @returns void
    */
   applyActualPlayerStats: async function (inventory) {
     if (!inventory || !inventory.level) return;
     if (!tiers) await init();
     if (inventory.level == 1) return;
-    const bonus = tiers[inventory.level].bonus;
-    if (inventory.speed) inventory.speed += bonus;
-    if (inventory.goalRate) inventory.goalRate += bonus;
-    if (inventory.power) inventory.power += bonus;
-    if (inventory.defense) inventory.defense += bonus;
-    if (inventory.stamina) inventory.stamina += bonus;
+    if (!("tierName" in inventory)) {
+      inventory.tierName = (
+        await playerPrisma.player.findFirst({
+          select: { TierName: true },
+          where: { playerId: inventory.PlayerId },
+        })
+      ).TierName;
+    }
+    const bonus = tiers[inventory.tierName].bonus[inventory.level];
+    if ("speed" in inventory) inventory.speed += bonus;
+    if ("goalRate" in inventory) inventory.goalRate += bonus;
+    if ("power" in inventory) inventory.power += bonus;
+    if ("defense" in inventory) inventory.defense += bonus;
+    if ("stamina" in inventory) inventory.stamina += bonus;
+  },
+
+  /**
+   * Get upgrade success rate for given 'tier' and 'level' from Tier table
+   * @param {Number} tier tier of a player
+   * @param {Number} level level of an inventory's player
+   * @returns Upgrade success rate at current 'level' of the 'tier'
+   */
+  getTierUpgradeSuccessRate: async function (tier, level) {
+    if (!tier && tier !== 0) return;
+    else if (!level && level !== 0) return;
+    if (typeof tier !== "number" || typeof level !== "number") return;
+    if (!tiers) await init();
+    if (tier >= tiers.length) return;
+    if (level >= Object.keys(tiers[tier].successRate).length) return;
+    return tiers[tier].successRate[level];
+  },
+
+  /**
+   * Get tier bonus for given 'tier' and 'level' from Tier table
+   * @param {Number} tier tier of a player
+   * @param {Number} level level of an inventory's player
+   * @returns stat bonus at current 'level' of the 'tier'
+   */
+  getTierStatBonus: async function (tier, level) {
+    if (!tier && tier !== 0) return;
+    else if (!level && level !== 0) return;
+    if (typeof tier !== "number" || typeof level !== "number") return;
+    if (!tiers) await init();
+    if (tier >= tiers.length) return;
+    if (level >= Object.keys(tiers[tier].bonus).length) return;
+    return tiers[tier].bonus[level];
   },
 };
 

--- a/src/lib/utils/tier-utils.js
+++ b/src/lib/utils/tier-utils.js
@@ -1,0 +1,30 @@
+import { playerPrisma } from "./prisma/index.js";
+
+let tiers = null;
+
+const init = async () => {
+  tiers = await playerPrisma.$queryRaw`
+    SELECT * FROM Tier
+  `;
+};
+
+const tierUtils = {
+  /**
+   * Applies actual player stats to the inventory's player data based on its level.
+   * @param {Object} inventory from table Inventory in game_db
+   * @returns void
+   */
+  applyActualPlayerStats: async function (inventory) {
+    if (!inventory || !inventory.level) return;
+    if (!tiers) await init();
+    if (inventory.level == 1) return;
+    const bonus = tiers[inventory.level].bonus;
+    if (inventory.speed) inventory.speed += bonus;
+    if (inventory.goalRate) inventory.goalRate += bonus;
+    if (inventory.power) inventory.power += bonus;
+    if (inventory.defense) inventory.defense += bonus;
+    if (inventory.stamina) inventory.stamina += bonus;
+  },
+};
+
+export default tierUtils;


### PR DESCRIPTION
## 관련 Issue

<!--관련 issue 번호를 #4, close #5 같은 형식으로 추가-->
<!-- close #1, #2, close #3 -->

없음

---

## 작업 내용

- inventory 라우터의 쿼리들이 queryRaw를 사용하도록 변경
- inventory 전체 조회가 반환하는 항목들에 playerName column을 추가
- inventory 단일 조회가 선수의 레벨에 따른 스탯 보너스를 반영하도록 변경
- inventory 단일 조회 시 받아온 req.body의 inventoryId가 요청의 유저에 속한 inventory인지 확인하지 않던 문제 수정

---

## 비고

<!--특이사항 작성-->

-
